### PR TITLE
Clarify expectation of suggest and ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each type of generator (e.g., Nelder-Nead, different flavors of GA, BO, etc.) wi
     - The values can either be `'MINIMIZE'` or `'MAXIMIZE'` to indicate whether the objective is to be maximized or minimized.
 
   - `variables` is a dictionary that lists the quantities that the generator can vary in order to optimize (i.e. either maximize or minimize) the objectives. Each variable is a floating point number (variables are scalars).
-    - The keys of this dictionary are the names of the variables. (The same names have to be used in the dictionaries passed to `ingest`, and are used in the dictionaries returned by `ingest`.)
+    - The keys of this dictionary are the names of the variables. (The same names must be used in the dictionaries passed to `ingest`, and in the dictionaries returned by `suggest`.)
     - The values are lists of two elements that specify the range of each variable.
 
   The constructor will also include variable positional and keyword arguments to
@@ -55,7 +55,7 @@ Each type of generator (e.g., Nelder-Nead, different flavors of GA, BO, etc.) wi
   - When `num_points` is not passed: the generator decides how many points to return.
     Different generators will return different number of points, by default. For instance, the simplex would return 1 or 3 points. A genetic algorithm could return the whole population. Batched Bayesian optimization would return the batch size (i.e., number of points that can be processed in parallel), which would be specified in the constructor.
 
-  - When it is passed: the generator should return exactly this number of points, or raise a error ``ValueError`` if it is unable to. If the user is flexible about the number of points, it should simply not pass `num_points`.
+  - When it is passed: the generator should return exactly this number of points, or raise a error `ValueError` if it is unable to. If the user is flexible about the number of points, they should simply not pass `num_points`.
 
   Examples:
 
@@ -71,7 +71,7 @@ Each type of generator (e.g., Nelder-Nead, different flavors of GA, BO, etc.) wi
 
 - `ingest(points: list[dict])`:
 
-  Feeds data (past evaluations) to the generator. Each element of the list is a separate point. Keys of the dictionary must include to the name of each variable and objective specified in the contructor.
+  Feeds data (past evaluations) to the generator. Each element of the list is a separate point. Keys of the dictionary must include the name of each variable and objective specified in the constructor.
 
   Example:
 


### PR DESCRIPTION
Clarify fields which will be returned by suggest,  and are expected for ingest.

### suggest

Currently: variables, _id (optional).

What about other information that may not be getting optimized. E.g. whether to run high or low fidelity simulation (or fidelity level). (Optimas `multitask` gen  returns `ax_trial_id`,  `arm_name` & `trial_type`.)

Also, clarify what happens if no number of points are requested, yet the return is nothing as the gen is in a finished state. Probably should still raise an exception rather than returning nothing. Also, should there be a distinct exception to indicate the gen is in a finished state.

### ingest

Currently: variables, objectives

Constraints, Observables as optionals?

### _id

Unique identifier. We should specify that when used, it must always be set by the generator.  so in the case of ingest being  called with points that were not given by suggest in this generator context (e.g. previous history points), we should support taking in points without an _id and be given an new id.
If points are given to ingest with an `_id` value that is not known internally,  it should raise an error.

---

Includes grammatical fixes.

Maybe incorporate into #22 

