### PR TITLE
Allow giving observable a type

### DIFF
--- a/generator_standard/tests/test_vocs.py
+++ b/generator_standard/tests/test_vocs.py
@@ -148,9 +148,12 @@ def test_vocs_1a():
             "y": {"a", "b", "c"},
         },
         objectives={"f": "MINIMIZE"},
+        observables={"temp": "float", "temp_array": (float, (2, 4))},
     )
     assert isinstance(vocs.variables["x"], ContinuousVariable)
     assert isinstance(vocs.variables["y"], DiscreteVariable)
+    assert vocs.observables["temp"] == "float"
+    assert vocs.observables["temp_array"] == (float, (2, 4))
 
 
 def check_objectives(vocs):

--- a/generator_standard/vocs.py
+++ b/generator_standard/vocs.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any
+from typing import Any, Union, Optional
 
 from pydantic import (
     ConfigDict,
@@ -36,6 +36,12 @@ class DiscreteVariable(BaseVariable):
     values: conset(Any, min_length=1) = Field(
         description="List of allowed discrete values"
     )
+
+
+class ObservableType(BaseModel):
+    """Type specification for observables."""
+    dtype: Optional[str] = Field(description="Data type of the observable (e.g., 'float', 'int', 'str')")
+    default_value: Any = Field(default=None, description="Default value for the observable")
 
 
 class BaseConstraint(BaseModel):
@@ -225,7 +231,7 @@ class VOCS(BaseModel):
     constants: dict[str, Any] = Field(
         default={}, description="constant names and values passed to evaluate function"
     )
-    observables: set[str] = Field(
+    observables: Union[set[str], dict[str, Union[str, ObservableType]]] = Field(
         default=set(),
         description="observation names tracked alongside objectives and constraints",
     )
@@ -318,8 +324,26 @@ class VOCS(BaseModel):
                     )
             else:
                 raise ValueError(f"objective input type {type(val)} not supported")
-
         return v
+
+    @field_validator("observables", mode="before")
+    def validate_observables(cls, v):
+        if isinstance(v, set):
+            return v
+        elif isinstance(v, list):
+            return set(v)
+        elif isinstance(v, dict):
+            # Validate observable types
+            for name, val in v.items():
+                if isinstance(val, str):
+                    v[name] = ObservableType(dtype=val)
+                elif isinstance(val, ObservableType):
+                    v[name] = val
+                else:
+                    raise ValueError(f"observable type {type(val)} not supported")
+            return v
+        else:
+            raise ValueError(f"observables input type {type(v)} not supported")
 
     @field_serializer("variables", "constraints")
     def serialize_objects(self, v):

--- a/generator_standard/vocs.py
+++ b/generator_standard/vocs.py
@@ -38,12 +38,6 @@ class DiscreteVariable(BaseVariable):
     )
 
 
-class ObservableType(BaseModel):
-    """Type specification for observables."""
-    dtype: Optional[Union[str, Tuple]] = Field(description="Data type of the observable")
-    default_value: Any = Field(default=None, description="Default value for the observable")
-
-
 class BaseConstraint(BaseModel):
     pass
 


### PR DESCRIPTION
Re: #39

`observables` can be given as either a set (of names - as before) or a dictionary (of names and types).

Type is either a string or tuple that can be used by other packages. E.g., used in Optimas as a dtype.

For example, Optimas observables can take a dtype parameter which tells libEnsemble how to allocate a field in the numpy array. In libEnsemble would be needed for `sim_specs["out"]`.

**Considerations**:

This means that the caller may pass in an observable value that is an array or other arbitrary type to an ingest. I don't think the standard restricts the type you are allowed to pass here, but I guess an individual generator might.

The same will apply to constraints, constants, and potentially objectives.
