### PR TITLE
Make all fields classes with type

### DIFF
--- a/generator_standard/tests/test_generator.py
+++ b/generator_standard/tests/test_generator.py
@@ -1,7 +1,12 @@
 import pytest
 import random
 from generator_standard.generator import Generator
-from generator_standard.vocs import VOCS, ContinuousVariable
+from generator_standard.vocs import (
+    VOCS,
+    ContinuousVariable,
+    MinimizeObjective,
+    MaximizeObjective,
+)
 
 
 class RandomGenerator(Generator):
@@ -53,14 +58,14 @@ class RandomGenerator(Generator):
                 self.data.append(r)
 
         # Set the best point
-        direction = self.vocs.objectives["f"].direction
+        obj = self.vocs.objectives["f"]
         for r in self.data:
             val = r.get("f")
             if self.best_point is None:
                 self.best_point = r
-            elif direction == "MINIMIZE" and val < self.best_point["f"]:
+            elif isinstance(obj, MinimizeObjective) and val < self.best_point["f"]:
                 self.best_point = r
-            elif direction == "MAXIMIZE" and val > self.best_point["f"]:
+            elif isinstance(obj, MaximizeObjective) and val > self.best_point["f"]:
                 self.best_point = r
 
     def finalize(self) -> None:
@@ -176,5 +181,5 @@ def test_gen_with_constraints():
     expected = {'x': 4.21, 'y': -2.41, 'f': 23.50, 'temp': 6.62, 'c': 6.62, 'c1': 1.79, 'c2': -4.82}
     actual = {k: round(gen.data[0][k], 2) for k in expected}
     assert actual == expected
-    assert list(gen.vocs.objectives.values())[0].direction == "MINIMIZE"
+    assert isinstance(list(gen.vocs.objectives.values())[0], MinimizeObjective)
     gen.finalize()

--- a/generator_standard/tests/test_generator.py
+++ b/generator_standard/tests/test_generator.py
@@ -26,7 +26,8 @@ class RandomGenerator(Generator):
         """Suggest points from the generator"""
         if num_points is None:
             num_points = 1
-        max_pts = self.vocs.constants.get("max_points")
+        max_pts_const = self.vocs.constants.get("max_points")
+        max_pts = max_pts_const.value if max_pts_const else None
         if max_pts is not None and num_points > max_pts:
             raise ValueError(f"Cannot supply more than {max_pts} points")
 
@@ -52,7 +53,7 @@ class RandomGenerator(Generator):
                 self.data.append(r)
 
         # Set the best point
-        direction = self.vocs.objectives["f"]
+        direction = self.vocs.objectives["f"].direction
         for r in self.data:
             val = r.get("f")
             if self.best_point is None:
@@ -175,5 +176,5 @@ def test_gen_with_constraints():
     expected = {'x': 4.21, 'y': -2.41, 'f': 23.50, 'temp': 6.62, 'c': 6.62, 'c1': 1.79, 'c2': -4.82}
     actual = {k: round(gen.data[0][k], 2) for k in expected}
     assert actual == expected
-    assert list(gen.vocs.objectives.values())[0] == "MINIMIZE"
+    assert list(gen.vocs.objectives.values())[0].direction == "MINIMIZE"
     gen.finalize()

--- a/generator_standard/tests/test_vocs.py
+++ b/generator_standard/tests/test_vocs.py
@@ -13,7 +13,7 @@ from generator_standard.vocs import (
     MaximizeObjective,
     ExploreObjective,
     Observable,
-    BaseConstant,
+    Constant,
 )
 
 
@@ -347,9 +347,9 @@ def test_objective_invalid_input_type():
 def test_constant_object_input():
     vocs = VOCS(
         variables={"x": [0, 1]},
-        constants={"c": BaseConstant(value=5)}
+        constants={"c": Constant(value=5)}
     )
-    assert isinstance(vocs.constants["c"], BaseConstant)
+    assert isinstance(vocs.constants["c"], Constant)
 
 
 def test_constant_dict_with_invalid_type():
@@ -364,15 +364,15 @@ def test_objective_dict_with_non_objective_class():
     with pytest.raises(ValueError, match="not available"):
         VOCS(
             variables={"x": [0, 1]},
-            objectives={"f": {"type": "BaseConstant"}}  # Valid class but not BaseObjective
+            objectives={"f": {"type": "Constant"}}  # Valid class but not BaseObjective
         )
 
 
 def test_constant_dict_construction():
     vocs = VOCS(
         variables={"x": [0, 1]},
-        constants={"c": {"type": "BaseConstant", "value": 42}}
+        constants={"c": {"type": "Constant", "value": 42}}
     )
-    assert isinstance(vocs.constants["c"], BaseConstant)
+    assert isinstance(vocs.constants["c"], Constant)
     assert vocs.constants["c"].value == 42
     

--- a/generator_standard/tests/test_vocs.py
+++ b/generator_standard/tests/test_vocs.py
@@ -12,6 +12,7 @@ from generator_standard.vocs import (
     MinimizeObjective,
     MaximizeObjective,
     ExploreObjective,
+    Observable,
 )
 
 
@@ -151,12 +152,15 @@ def test_vocs_1a():
             "y": {"a", "b", "c"},
         },
         objectives={"f": "MINIMIZE"},
-        observables={"temp": "float", "temp_array": (float, (2, 4))},
+        # observables={"temp": "float", "temp_array": (float, (2, 4))},
+        observables={"temp": "float"},
     )
     assert isinstance(vocs.variables["x"], ContinuousVariable)
     assert isinstance(vocs.variables["y"], DiscreteVariable)
-    assert vocs.observables["temp"] == "float"
-    assert vocs.observables["temp_array"] == (float, (2, 4))
+    assert isinstance(vocs.observables["temp"], Observable)
+    assert vocs.observables["temp"].dtype == "float"
+    # assert isinstance(vocs.observables["temp_array"], Observable)
+    # assert vocs.observables["temp_array"].dtype == (float, (2, 4))
 
 
 def check_objectives(vocs):

--- a/generator_standard/tests/test_vocs.py
+++ b/generator_standard/tests/test_vocs.py
@@ -9,6 +9,9 @@ from generator_standard.vocs import (
     LessThanConstraint,
     ConstraintTypeEnum,
     ObjectiveTypeEnum,
+    MinimizeObjective,
+    MaximizeObjective,
+    ExploreObjective,
 )
 
 
@@ -107,7 +110,7 @@ def test_unsupported_constraint_type():
 
 def test_objective_enum_case_insensitive():
     vocs = VOCS(variables={"x": [0.0, 1.0]}, objectives={"f": "minimize"})
-    assert vocs.objectives["f"].direction == "MINIMIZE"
+    assert isinstance(vocs.objectives["f"], MinimizeObjective)
 
 
 def test_invalid_objective_enum_value():
@@ -134,7 +137,7 @@ def test_vocs_1():
     )
     assert isinstance(vocs.variables["x"], ContinuousVariable)
     assert vocs.variables["x"].domain == [0.5, 1.0]
-    assert vocs.objectives["f"].direction == "MINIMIZE"
+    assert isinstance(vocs.objectives["f"], MinimizeObjective)
     assert vocs.constants["alpha"].value == 1.0
     assert vocs.constants["beta"].value == 2.0
     assert "temp" in vocs.observables
@@ -157,10 +160,10 @@ def test_vocs_1a():
 
 
 def check_objectives(vocs):
-    expected = {"f": "MINIMIZE", "f2": "MAXIMIZE", "f3": "EXPLORE"}
+    expected = {"f": MinimizeObjective, "f2": MaximizeObjective, "f3": ExploreObjective}
     for key, val in expected.items():
-        assert vocs.objectives[key].direction == val, (
-            f"{key} expected {val}, got {vocs.objectives[key].direction}"
+        assert isinstance(vocs.objectives[key], val), (
+            f"{key} expected {val}, got {type(vocs.objectives[key])}"
         )
 
 

--- a/generator_standard/tests/test_vocs.py
+++ b/generator_standard/tests/test_vocs.py
@@ -107,7 +107,7 @@ def test_unsupported_constraint_type():
 
 def test_objective_enum_case_insensitive():
     vocs = VOCS(variables={"x": [0.0, 1.0]}, objectives={"f": "minimize"})
-    assert vocs.objectives["f"] == "MINIMIZE"
+    assert vocs.objectives["f"].direction == "MINIMIZE"
 
 
 def test_invalid_objective_enum_value():
@@ -134,9 +134,9 @@ def test_vocs_1():
     )
     assert isinstance(vocs.variables["x"], ContinuousVariable)
     assert vocs.variables["x"].domain == [0.5, 1.0]
-    assert vocs.objectives["f"] == "MINIMIZE"
-    assert vocs.constants["alpha"] == 1.0
-    assert vocs.constants["beta"] == 2.0
+    assert vocs.objectives["f"].direction == "MINIMIZE"
+    assert vocs.constants["alpha"].value == 1.0
+    assert vocs.constants["beta"].value == 2.0
     assert "temp" in vocs.observables
     assert "temp2" in vocs.observables
 
@@ -159,8 +159,8 @@ def test_vocs_1a():
 def check_objectives(vocs):
     expected = {"f": "MINIMIZE", "f2": "MAXIMIZE", "f3": "EXPLORE"}
     for key, val in expected.items():
-        assert vocs.objectives[key] == val, (
-            f"{key} expected {val}, got {vocs.objectives[key]}"
+        assert vocs.objectives[key].direction == val, (
+            f"{key} expected {val}, got {vocs.objectives[key].direction}"
         )
 
 

--- a/generator_standard/tests/test_vocs.py
+++ b/generator_standard/tests/test_vocs.py
@@ -148,9 +148,12 @@ def test_vocs_1a():
             "y": {"a", "b", "c"},
         },
         objectives={"f": "MINIMIZE"},
+        observables={"temp": "float", "temp_array": (float, (2, 4))},
     )
     assert isinstance(vocs.variables["x"], ContinuousVariable)
     assert isinstance(vocs.variables["y"], DiscreteVariable)
+    assert vocs.observables["temp"] == "float"
+    assert vocs.observables["temp_array"] == (float, (2, 4))
 
 
 def check_objectives(vocs):

--- a/generator_standard/tests/test_vocs.py
+++ b/generator_standard/tests/test_vocs.py
@@ -270,6 +270,8 @@ def test_vocs_serialization_deserialization():
             "c1": ["LESS_THAN", 2.0],
             "c2": ["BOUNDS", -1.0, 1.0],
         },
+        # observables=["temp"],
+        observables={"temp": "float", "temp2": "int"},        
     )
 
     # Serialize to JSON

--- a/generator_standard/tests/test_vocs.py
+++ b/generator_standard/tests/test_vocs.py
@@ -305,14 +305,11 @@ def test_vocs_observable_object_input():
 
 
 def test_invalid_observables_input():
-    try:
+    with pytest.raises(ValueError, match="observables input type"):
         VOCS(
             variables={"x": [0, 1]},
             observables=123  # invalid type
         )
-        assert False, "Should have raised ValueError"
-    except ValueError as e:
-        assert "observables input type" in str(e)
 
 
 def test_objective_object_input():
@@ -324,36 +321,27 @@ def test_objective_object_input():
 
 
 def test_objective_dict_with_invalid_type():
-    try:
+    with pytest.raises(ValueError, match="not available"):
         VOCS(
             variables={"x": [0, 1]},
             objectives={"f": {"type": "InvalidObjective"}}
         )
-        assert False, "Should have raised ValueError"
-    except ValueError as e:
-        assert "not available" in str(e)
 
 
 def test_objective_dict_missing_type():
-    try:
+    with pytest.raises(ValueError, match="not correctly specified"):
         VOCS(
             variables={"x": [0, 1]},
             objectives={"f": {"some_field": "value"}}
         )
-        assert False, "Should have raised ValueError"
-    except ValueError as e:
-        assert "not correctly specified" in str(e)
 
 
 def test_objective_invalid_input_type():
-    try:
+    with pytest.raises(ValueError, match="not supported"):
         VOCS(
             variables={"x": [0, 1]},
             objectives={"f": 123}
         )
-        assert False, "Should have raised ValueError"
-    except ValueError as e:
-        assert "not supported" in str(e)
 
 
 def test_constant_object_input():
@@ -365,25 +353,19 @@ def test_constant_object_input():
 
 
 def test_constant_dict_with_invalid_type():
-    try:
+    with pytest.raises(ValueError, match="not available"):
         VOCS(
             variables={"x": [0, 1]},
             constants={"c": {"type": "InvalidConstant", "value": 5}}
         )
-        assert False, "Should have raised ValueError"
-    except ValueError as e:
-        assert "not available" in str(e)
 
 
 def test_objective_dict_with_non_objective_class():
-    try:
+    with pytest.raises(ValueError, match="not available"):
         VOCS(
             variables={"x": [0, 1]},
             objectives={"f": {"type": "BaseConstant"}}  # Valid class but not BaseObjective
         )
-        assert False, "Should have raised ValueError"
-    except ValueError as e:
-        assert "not available" in str(e)
 
 
 def test_constant_dict_construction():

--- a/generator_standard/vocs.py
+++ b/generator_standard/vocs.py
@@ -277,7 +277,8 @@ class VOCS(BaseModel):
             elif isinstance(val, list):
                 if len(val) != 2:
                     raise ValueError(
-                        f"variable {val} is not correctly specified, must have two elements representing upper and lower bounds."
+                        f"variable {val} is not correctly specified, "
+                        f"must have two elements representing upper and lower bounds."
                     )
                 v[name] = ContinuousVariable(domain=val)
             elif isinstance(val, set):
@@ -293,7 +294,11 @@ class VOCS(BaseModel):
                 v[name] = class_(**val)
 
             else:
-                raise ValueError(f"variable input type {type(val)} not supported. Must be a list of two elements representing upper and lower bounds *or* a set of possible values to sample.")
+                raise ValueError(
+                    f"variable input type {type(val)} not supported. "
+                    f"Must be a list of two elements representing upper and lower bounds "
+                    f"*or* a set of possible values to sample."
+                )
 
         return v
 

--- a/generator_standard/vocs.py
+++ b/generator_standard/vocs.py
@@ -286,7 +286,6 @@ class VOCS(BaseModel):
                     )
                 v[name] = class_(**val)
             else:
-                # For backward compatibility, wrap raw values in BaseConstant
                 v[name] = BaseConstant(value=val)
         return v
 
@@ -313,16 +312,14 @@ class VOCS(BaseModel):
         output = {}
         for name, val in v.items():
             output[name] = val.model_dump() | {"type": type(val).__name__}
-
         return output
 
     @field_serializer("observables")
     def serialize_observables(self, v):
         if isinstance(v, set):
             return list(v)
-        elif isinstance(v, dict):
+        else:
             output = {}
             for name, val in v.items():
                 output[name] = val.model_dump() | {"type": type(val).__name__}
             return output
-        return v

--- a/generator_standard/vocs.py
+++ b/generator_standard/vocs.py
@@ -299,6 +299,9 @@ class VOCS(BaseModel):
             for name, val in v.items():
                 if isinstance(val, Observable):
                     output[name] = val
+                elif isinstance(val, dict):
+                    val.pop("type", None)
+                    output[name] = Observable(**val)
                 else:
                     output[name] = Observable(dtype=val)
             return output

--- a/generator_standard/vocs.py
+++ b/generator_standard/vocs.py
@@ -302,11 +302,3 @@ class VOCS(BaseModel):
             output[name] = val.model_dump() | {"type": type(val).__name__}
 
         return output
-
-    @field_serializer("observables")
-    def serialize_observables(self, v):
-        if isinstance(v, set):
-            return list(v)
-        elif isinstance(v, dict):
-            return v
-        return v

--- a/generator_standard/vocs.py
+++ b/generator_standard/vocs.py
@@ -76,10 +76,6 @@ class BoundsConstraint(BaseConstraint):
         return lo <= x <= hi  # open both ends
 
 
-class BaseConstant(BaseField):
-    value: Any
-
-
 CONSTRAINT_CLASSES = {
     "LESS_THAN": LessThanConstraint,
     "GREATER_THAN": GreaterThanConstraint,
@@ -135,6 +131,10 @@ OBJECTIVE_CLASSES = {
     "MAXIMIZE": MaximizeObjective,
     "EXPLORE": ExploreObjective,
 }
+
+
+class BaseConstant(BaseField):
+    value: Any
 
 
 class Observable(BaseField):

--- a/generator_standard/vocs.py
+++ b/generator_standard/vocs.py
@@ -133,7 +133,7 @@ OBJECTIVE_CLASSES = {
 }
 
 
-class BaseConstant(BaseField):
+class Constant(BaseField):
     value: Any
 
 
@@ -155,7 +155,7 @@ class VOCS(BaseModel):
         default={},
         description="constraint names with a list of constraint type and value",
     )
-    constants: dict[str, BaseConstant] = Field(
+    constants: dict[str, Constant] = Field(
         default={}, description="constant names and values passed to evaluate function"
     )
     observables: Union[set[str], dict[str, Observable]] = Field(
@@ -274,7 +274,7 @@ class VOCS(BaseModel):
     def validate_constants(cls, v):
         assert isinstance(v, dict)
         for name, val in v.items():
-            if isinstance(val, BaseConstant):
+            if isinstance(val, Constant):
                 v[name] = val
             elif isinstance(val, dict):
                 constant_type = val.pop("type")
@@ -286,7 +286,7 @@ class VOCS(BaseModel):
                     )
                 v[name] = class_(**val)
             else:
-                v[name] = BaseConstant(value=val)
+                v[name] = Constant(value=val)
         return v
 
     @field_validator("observables", mode="before")

--- a/generator_standard/vocs.py
+++ b/generator_standard/vocs.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any
+from typing import Any, Union, Optional
 
 from pydantic import (
     ConfigDict,
@@ -36,6 +36,12 @@ class DiscreteVariable(BaseVariable):
     values: conset(Any, min_length=1) = Field(
         description="List of allowed discrete values"
     )
+
+
+class ObservableType(BaseModel):
+    """Type specification for observables."""
+    dtype: Optional[str] = Field(description="Data type of the observable (e.g., 'float', 'int', 'str')")
+    default_value: Any = Field(default=None, description="Default value for the observable")
 
 
 class BaseConstraint(BaseModel):
@@ -225,7 +231,7 @@ class VOCS(BaseModel):
     constants: dict[str, Any] = Field(
         default={}, description="constant names and values passed to evaluate function"
     )
-    observables: set[str] = Field(
+    observables: Union[set[str], dict[str, Union[str, ObservableType]]] = Field(
         default=set(),
         description="observation names tracked alongside objectives and constraints",
     )
@@ -318,8 +324,26 @@ class VOCS(BaseModel):
                     )
             else:
                 raise ValueError(f"objective input type {type(val)} not supported")
-
         return v
+
+    @field_validator("observables", mode="before")
+    def validate_observables(cls, v):
+        if isinstance(v, set):
+            return v
+        elif isinstance(v, list):
+            return set(v)
+        elif isinstance(v, dict):
+            # Validate observable types
+            for name, val in v.items():
+                if isinstance(val, str):
+                    v[name] = ObservableType(dtype=val)
+                elif isinstance(val, ObservableType):
+                    v[name] = val
+                else:
+                    raise ValueError(f"observable type {type(val)} not supported")
+            return v
+        else:
+            raise ValueError(f"observables input type {type(v)} not supported")
 
     @field_serializer("variables", "constraints")
     def serialize_objects(self, v):

--- a/generator_standard/vocs.py
+++ b/generator_standard/vocs.py
@@ -38,12 +38,6 @@ class DiscreteVariable(BaseVariable):
     )
 
 
-class ObservableType(BaseModel):
-    """Type specification for observables."""
-    dtype: Optional[Union[str, Tuple]] = Field(description="Data type of the observable")
-    default_value: Any = Field(default=None, description="Default value for the observable")
-
-
 class BaseConstraint(BaseModel):
     pass
 


### PR DESCRIPTION
All fields use classes - with all having a datatype specifiable. Defaults to None.

Targets  #40. More complete resolution to #39 

Currently takes string for datatype (can add tuple).

- General issue that when constants and objectives become a class then they need an attribute for what was previously the direct storage of that field.
  - This is breaking as it is
  - We could use magic methods to continue to make direct use of the object refer to that attribute (but possible confusion).
 - E.g., Objective class - added direction attribute:

```python
    assert vocs.objectives["f"] == "MINIMIZE"
    assert vocs.constants["alpha"] == 1.0
```
to 

```python
    assert vocs.objectives["f"].direction == "MINIMIZE"
    assert vocs.constants["alpha"].value == 1.0
```

**Update**: Objectives now use inherited classes.

```python
assert isinstance(vocs.objectives["f"], MinimizeObjective)
```

- Should dtype be string/tuple (numpy centric) or separate type, size fields?
  - Maybe latter more intuitive if a generators validate_vocs limits values to scalars.

- Should we constrain types for variables for instance - somehow?

- Can we have a `ContinuousVariable` of integer type or should we have separate `IntegerVariable` as before.

- If we do like this, we could make `constraints` just `observables` with an optional `constraint` attribute. 
